### PR TITLE
fix check for ErrSkip and ErrCancel

### DIFF
--- a/error.go
+++ b/error.go
@@ -18,9 +18,17 @@ type ErrPanic struct{ error }
 type ErrInput struct{ error }
 
 func (e ErrCancel) Unwrap() error { return e.error }
-func (e ErrSkip) Unwrap() error   { return e.error }
-func (e ErrPanic) Unwrap() error  { return e.error }
-func (e ErrInput) Unwrap() error  { return e.error }
+func (e ErrCancel) Is(err error) bool {
+	_, ok := err.(ErrCancel)
+	return ok
+}
+func (e ErrSkip) Unwrap() error { return e.error }
+func (e ErrSkip) Is(err error) bool {
+	_, ok := err.(ErrSkip)
+	return ok
+}
+func (e ErrPanic) Unwrap() error { return e.error }
+func (e ErrInput) Unwrap() error { return e.error }
 
 // StatusError contains the status and error of a Step.
 type StatusError struct {

--- a/example/04_condition_when_test.go
+++ b/example/04_condition_when_test.go
@@ -77,6 +77,10 @@ func ExampleConditionWhen() {
 	// AnyFailed
 	fmt.Println(workflow.StateOf(allSucceeded).GetStatus())
 	// Skipped
+	fmt.Println(workflow.StateOf(skipped).GetStatus())
+	// Skipped
+	fmt.Println(workflow.StateOf(canceled).GetStatus())
+	// Canceled
 
 	workflow = new(flow.Workflow)
 	workflow.Add(
@@ -99,6 +103,8 @@ func ExampleConditionWhen() {
 	// Output:
 	// AnyFailed
 	// Skipped
+	// Skipped
+	// Canceled
 	// Always
 	// BeCanceled
 	// Canceled

--- a/workflow.go
+++ b/workflow.go
@@ -397,7 +397,7 @@ func (w *Workflow) tick(ctx context.Context) bool {
 				result = Succeeded
 			case DefaultIsCanceled(err):
 				result = Canceled
-			case errors.Is(err, &ErrSkip{}):
+			case errors.Is(err, ErrSkip{}):
 				result = Skipped
 			default:
 				result = Failed


### PR DESCRIPTION
Fix bug:
when step return
```go
func (s *StepImpl) Do(ctx context.Context) error {
    return flow.Skip(fmt.Errorf("skip me"))
}
```
the previous check will mark the above step `Failed` instead of `Skipped`