### PR TITLE
make Cancel() and Skip() only take effect on top layer, and Unwrap them after resolving StepStatus

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -46,10 +46,10 @@ var (
 	DefaultCondition Condition = AllSucceeded
 	// DefaultIsCanceled is used to determine whether an error is being regarded as canceled.
 	DefaultIsCanceled = func(err error) bool {
-		switch {
+		switch _, isCancel := err.(ErrCancel); {
 		case errors.Is(err, context.Canceled),
 			errors.Is(err, context.DeadlineExceeded),
-			errors.Is(err, ErrCancel{}):
+			isCancel:
 			return true
 		}
 		return false


### PR DESCRIPTION
```go
func (s *SomeStepImpl) Do(ctx context.Context) error {
	err := flow.Cancel(fmt.Errorf("some error"))
	return err // this will cancel the step
	return fmt.Errorf("wrap error: %w", err) // this will not cancel the step, but fail it
}
```

and 

```go
err := workflow.Do(ctx)
errWorkflow := flow.ErrWorkflow{}
if errors.As(err, &errWorkflow) {
	errWorkflow[skippedStep].Status // Skipped
	errWorkflow[skippedStep].Err // NOT ErrSkip, but the inner error!
}
```