### PR TITLE
Add OkToSkip option to Workflow and ErrSucceed to mark a step Succeeded manually

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -46,10 +46,10 @@ var (
 	DefaultCondition Condition = AllSucceeded
 	// DefaultIsCanceled is used to determine whether an error is being regarded as canceled.
 	DefaultIsCanceled = func(err error) bool {
-		switch _, isCancel := err.(ErrCancel); {
+		switch {
 		case errors.Is(err, context.Canceled),
 			errors.Is(err, context.DeadlineExceeded),
-			isCancel:
+			StatusFromError(err) == Canceled:
 			return true
 		}
 		return false

--- a/error.go
+++ b/error.go
@@ -139,9 +139,7 @@ func (e ErrWorkflow) Unwrap() []error {
 }
 func (e ErrWorkflow) AllSucceeded() bool {
 	for _, sErr := range e {
-		switch {
-		case sErr.Status == Succeeded && sErr.Err == nil:
-		default:
+		if sErr.Status != Succeeded {
 			return false
 		}
 	}
@@ -149,9 +147,8 @@ func (e ErrWorkflow) AllSucceeded() bool {
 }
 func (e ErrWorkflow) AllSucceededOrSkipped() bool {
 	for _, sErr := range e {
-		switch {
-		case sErr.Status == Succeeded && sErr.Err == nil:
-		case sErr.Status == Skipped: // skipped step can have error to indicate why it's skipped
+		switch sErr.Status {
+		case Succeeded, Skipped: // skipped step can have error to indicate why it's skipped
 		default:
 			return false
 		}

--- a/workflow.go
+++ b/workflow.go
@@ -42,6 +42,7 @@ type Workflow struct {
 	notify            []Notify       // notify before and after Step
 
 	DontPanic bool // whether recover panic from Step(s)
+	OkToSkip  bool // whether returns nil when some Steps are skipped
 }
 
 // Add Steps into Workflow in phase Main.
@@ -272,7 +273,10 @@ func (w *Workflow) Do(ctx context.Context) error {
 	for step, state := range w.state {
 		err[step] = state.GetStatusError()
 	}
-	if err.AllSucceeded() {
+	if w.OkToSkip && err.AllSucceededOrSkipped() {
+		return nil
+	}
+	if !w.OkToSkip && err.AllSucceeded() {
 		return nil
 	}
 	return err


### PR DESCRIPTION
This PR is trying to solve expected skip steps, and don't want to regard the skip as "error".
```
w.Add(
    flow.Step(skipStep),
)
w.OkToSkip = true  // w.Do(ctx) == nil
w.OkToSkip = false // w.Do(ctx) == ErrWorkflow{skipStep: {Status: Skipped, Error: "reason"}}
```