### PR TITLE
Add StackTraces for panic in Workflow

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -537,6 +539,9 @@ func catchPanicAsError(f func() error) error {
 				default:
 					*err = fmt.Errorf("%s", r)
 				}
+				*err = WithStackTraces(4, 32, func(f runtime.Frame) bool {
+					return strings.HasPrefix(f.Function, "github.com/Azure/go-workflow")
+				})(*err)
 				*err = ErrPanic{*err}
 			}
 		}()


### PR DESCRIPTION
when panic happens in workflow and `.DontPanic = true`, a stack trace will be printed with
<img width="657" alt="image" src="https://github.com/Azure/go-workflow/assets/28257575/632179b8-d240-4481-a117-dd34ea9b841f">
