### PR TITLE
bugfix: fix a nil Step will break HasStep check

### DIFF
--- a/build_step.go
+++ b/build_step.go
@@ -20,15 +20,16 @@ func (sb *StepBuilder) BuildStep(s Steper) {
 	}
 	Traverse(s, func(s Steper, walked []Steper) TraverseDecision {
 		if sb.built.Has(s) {
-			return TraverseDecision{Continue: false}
+			return TraverseEndBranch // already built
 		}
 		if _, ok := s.(interface{ BuildStep(Steper) }); ok {
-			return TraverseDecision{Continue: false}
+			return TraverseEndBranch // it's a sub-workflow, let it manage its own steps
 		}
 		if b, ok := s.(interface{ BuildStep() }); ok {
 			b.BuildStep()
 			sb.built.Add(s)
+			return TraverseEndBranch // not necessary to go deeper
 		}
-		return TraverseDecision{Continue: true}
+		return TraverseContinue
 	})
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -39,6 +39,16 @@ func TestAdd(t *testing.T) {
 		workflow.Add(Steps(nil))
 		assert.Nil(t, workflow.Steps())
 	})
+	t.Run("add nil step should not break HasStep", func(t *testing.T) {
+		a := NoOp("a")
+		w := new(Workflow).Add(
+			Step(a),
+			Name(nil, "nil step"),
+		)
+		for i := 0; i < 100; i++ {
+			assert.True(t, HasStep(w, a))
+		}
+	})
 	t.Run("add new step", func(t *testing.T) {
 		workflow := new(Workflow)
 		a := NoOp("a")


### PR DESCRIPTION
adding a nil step into workflow, will potentially break `HasStep` check, due to miss handling the nil case
```go
step := &SomeStep{}
w.Add(
    flow.Step(step),
    flow.Name(nil, "nil step"),
)

flow.HasStep(w, step) // this is randomly be true and false
```

because

```go
	for {
		if s == nil {
			return TraverseDecision{} // this is equivalent to TraverseStop
		}
```

so when `HasStep` traverse `w`, sometimes it checks `step` first, then return `true`;
sometimes it checks `nil` first, then just stop the traversal and return `false`.

So fix will be a verbose enum `TraverseDecision` and make nil returns
```go
	for {
		if s == nil {
			return TraverseEndBranch
		}
```