### PR TITLE
Add statusChange sync.Cond to decrease cpu time

### DIFF
--- a/step.go
+++ b/step.go
@@ -251,7 +251,7 @@ func (as AddSteps) Retry(opts ...func(*RetryOption)) AddSteps {
 	return as
 }
 
-// AddToWorkflow implements WorkflowAdder
+// AddToWorkflow implements Builder
 func (as AddSteps) AddToWorkflow() map[Steper]*StepConfig { return as }
 
 // Merge another AddSteps into one.

--- a/visual/react/server_test.go
+++ b/visual/react/server_test.go
@@ -1,0 +1,53 @@
+package react_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	flow "github.com/Azure/go-workflow"
+	"github.com/Azure/go-workflow/visual/react"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaticHandler(t *testing.T) {
+	var (
+		a  = flow.NoOp("A")
+		b  = flow.NoOp("B")
+		c  = flow.NoOp("C")
+		ab = new(flow.Workflow).Add(
+			flow.Step(b).DependsOn(a),
+		)
+		abc = new(flow.Workflow).Add(
+			flow.Step(c).DependsOn(ab),
+		)
+	)
+	sh := &react.StaticHandler{Workflow: abc}
+
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(sh.ServeHTTP)
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var root react.Node
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &root))
+	assert.Equal(t, "root", root.ID)
+	if assert.Len(t, root.Children, 2) {
+		for _, child := range root.Children {
+			if len(child.Children) == 0 {
+				assert.Equal(t, "C", child.Labels[0].Text)
+			} else {
+				if assert.Len(t, child.Children, 2) {
+					for _, grandchild := range child.Children {
+						assert.Contains(t, []string{"A", "B"}, grandchild.Labels[0].Text)
+					}
+				}
+			}
+		}
+	}
+}

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -29,7 +29,7 @@ func TestNil(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	t.Parallel()
-	t.Run("add nil WorkflowAdder", func(t *testing.T) {
+	t.Run("add nil Builder", func(t *testing.T) {
 		workflow := new(Workflow)
 		workflow.Add(nil)
 		assert.Nil(t, workflow.Steps())


### PR DESCRIPTION
Before this change,
`workflow.Do` has an infinite loop eating all cpu time
```go
for {
    if done := w.tick(ctx); done {
        break
    }
}
```
even step goroutine is idle or waiting for network io.

Now, leveraging `sync.Cond`, the loop only iterates when some step status is changed,
```go
for {
    if done := w.tick(ctx); done {
        break
    }
    w.statusChange.Wait()
}
```