### PR TITLE
fix deadlock in statusChange sync.Cond

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -379,8 +379,10 @@ func (w *Workflow) tick(ctx context.Context) bool {
 			w.waitGroup.Add(1)
 			go func() {
 				defer w.waitGroup.Done()
+				w.statusChange.L.Lock()
 				state.SetStatus(nextStatus)
 				w.statusChange.Signal()
+				w.statusChange.L.Unlock()
 			}()
 			continue
 		}
@@ -397,8 +399,10 @@ func (w *Workflow) tick(ctx context.Context) bool {
 				status = Failed
 			)
 			defer func() {
+				w.statusChange.L.Lock()
 				state.SetStatus(status)
 				w.statusChange.Signal()
+				w.statusChange.L.Unlock()
 				state.SetError(err)
 			}()
 


### PR DESCRIPTION
statusChange.Wait could be blocked when it's after all Signals fired

```go
w.statusChange.L.Lock()
for {
	if done := w.tick(ctx); done {	// A: kick step goroutines here
		break
	}
	w.statusChange.Wait()		// B: wait for step goroutines here
}
w.statusChange.L.Unlock()
```

```go
go func(ctx context.Context, step Steper, state *State) {
	...
	defer func() {
		state.SetStatus(status)
		w.statusChange.Signal()	// C: signal statusChange here
		state.SetError(err)
	}()
```

The deadlock condition is when `A --> C --> B`