### PR TITLE
fix: shared Backoff data race and MaxConcurrency=1 deadlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/settings.local.json
+.worktrees/

--- a/retry.go
+++ b/retry.go
@@ -47,6 +47,11 @@ func (w *Workflow) retry(opt *RetryOption) func(
 	}
 	return func(ctx context.Context, do func(context.Context) error, notAfter time.Time) error {
 		backOff := opt.Backoff
+		if backOff == nil {
+			// Backoff was not set (or was cleared to avoid sharing DefaultRetryOption's
+			// mutable Backoff instance). Allocate a fresh one for this retry run.
+			backOff = backoff.NewExponentialBackOff()
+		}
 		backOff = backoff.WithContext(backOff, ctx)
 		if !notAfter.IsZero() {
 			backOff = &backOffStopIfTimeout{BackOff: backOff, NotAfter: notAfter, Now: w.Clock.Now}

--- a/retry_test.go
+++ b/retry_test.go
@@ -3,6 +3,7 @@ package flow_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -168,4 +169,39 @@ func (t *testTimer) Start(duration time.Duration) {
 
 func (t *testTimer) Stop() {
 	t.timer.Stop()
+}
+
+// TestRetrySharedBackoffDataRace verifies that steps using Retry(nil) (which
+// copies DefaultRetryOption) do not share the same Backoff instance.
+// Before the fix, all such steps shared the same *ExponentialBackOff pointer
+// (shallow copy), causing a data race under concurrent retries.
+// Run with -race to catch the race; without -race it checks attempt counts
+// are not corrupted by concurrent resets.
+func TestRetrySharedBackoffDataRace(t *testing.T) {
+	t.Parallel()
+	const numSteps = 5
+	const wantAttempts = 3
+
+	type counter struct{ n atomic.Int64 }
+	counters := make([]counter, numSteps)
+
+	w := &flow.Workflow{}
+	for i := range numSteps {
+		i := i
+		s := flow.Func("step-"+string(rune('A'+i)), func(ctx context.Context) error {
+			if counters[i].n.Add(1) < wantAttempts {
+				return assert.AnError
+			}
+			return nil
+		})
+		// Retry(nil) triggers shallow-copy of DefaultRetryOption,
+		// sharing the same Backoff pointer across all steps before the fix.
+		w.Add(flow.Step(s).Retry(nil))
+	}
+
+	assert.NoError(t, w.Do(context.Background()))
+	for i := range numSteps {
+		assert.Equal(t, int64(wantAttempts), counters[i].n.Load(),
+			"step %c attempt count should not be corrupted by shared Backoff", rune('A'+i))
+	}
 }

--- a/step.go
+++ b/step.go
@@ -280,6 +280,11 @@ func (as AddSteps) Retry(opts ...func(*RetryOption)) AddSteps {
 			if so.RetryOption == nil {
 				so.RetryOption = new(RetryOption)
 				*so.RetryOption = DefaultRetryOption
+				// Deep-copy: Backoff holds a pointer to mutable state.
+				// A shallow copy shares the same instance across all steps that
+				// call Retry(nil), causing a data race when they retry concurrently.
+				// Set to nil so retry() falls back to a freshly allocated instance.
+				so.RetryOption.Backoff = nil
 			}
 			for _, opt := range opts {
 				if opt != nil {

--- a/workflow.go
+++ b/workflow.go
@@ -398,13 +398,18 @@ func (w *Workflow) tick(ctx context.Context) bool {
 			w.waitGroup.Add(1)
 			go func(ctx context.Context, step Steper, state *State) {
 				defer w.waitGroup.Done()
-				defer w.unlease()
 
 				var err error
 				status := Failed
 				defer func() {
 					state.SetStatus(status)
 					state.SetError(err)
+					// Release the lease BEFORE signalling, so that when the main
+					// loop wakes up in tick() it can immediately acquire a new lease.
+					// Previously unlease() was a separate earlier defer (LIFO), meaning
+					// signal fired first → tick() saw a full bucket → went back to
+					// Wait() → deadlock when MaxConcurrency=1 with chained steps.
+					w.unlease()
 					w.signalStatusChange()
 				}()
 

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -657,4 +658,61 @@ func TestSubWorkflow(t *testing.T) {
 	assert.NoError(t, w.Do(context.Background()))
 	assert.True(t, Has[*NoOpStep](w))
 	assert.Equal(t, "inner", As[*NoOpStep](w)[0].Name)
+}
+
+// TestMaxConcurrencyDeadlock verifies that a workflow with MaxConcurrency=1
+// and a dependency chain (a → b → c) completes without deadlock.
+//
+// Before the fix, a step's goroutine called signalStatusChange() *before*
+// unlease(), so the main loop could wake up, fail to acquire the lease, go
+// back to Wait(), and then never be woken again after the lease was released.
+func TestMaxConcurrencyDeadlock(t *testing.T) {
+	t.Parallel()
+	a, b, c := NoOp("a"), NoOp("b"), NoOp("c")
+	w := &Workflow{MaxConcurrency: 1}
+	w.Add(
+		Step(a),
+		Step(b).DependsOn(a),
+		Step(c).DependsOn(b),
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- w.Do(context.Background()) }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: workflow with MaxConcurrency=1 did not complete within 5s")
+	}
+}
+
+// TestMaxConcurrencyDeadlockStress runs many concurrent workflow chains to
+// shake out the race between lease release and status-change signalling.
+func TestMaxConcurrencyDeadlockStress(t *testing.T) {
+	t.Parallel()
+	const rounds = 100
+	var wg sync.WaitGroup
+	for range rounds {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a, b, c := NoOp("a"), NoOp("b"), NoOp("c")
+			w := &Workflow{MaxConcurrency: 1}
+			w.Add(
+				Step(a),
+				Step(b).DependsOn(a),
+				Step(c).DependsOn(b),
+			)
+			done := make(chan error, 1)
+			go func() { done <- w.Do(context.Background()) }()
+			select {
+			case err := <-done:
+				assert.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				t.Errorf("deadlock detected in stress round")
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- **Bug 1** (`step.go`, `retry.go`): `Retry(nil)` shallow-copies `DefaultRetryOption`, causing all such steps to share the same `*ExponentialBackOff` pointer. Concurrent retries across steps produce a data race on the backoff's internal state. Fix: clear `Backoff` to nil after the shallow copy; `retry()` allocates a fresh `backoff.NewExponentialBackOff()` when `Backoff` is nil.
- **Bug 2** (`workflow.go`): With `MaxConcurrency=1`, the step goroutine's defers ran in LIFO order: `signalStatusChange()` fired before `unlease()`. The main loop woke up, found the lease bucket still full, returned to `Wait()`, and then the lease was released with no further signal — deadlock. Fix: merge `unlease()` into the status-setting defer so the lease is always released before the signal is sent.

## Test plan

- [x] `TestRetrySharedBackoffDataRace` — 5 concurrent steps with `Retry(nil)`, detected by `-race` as a write-write race on `*ExponentialBackOff`
- [x] `TestMaxConcurrencyDeadlock` — `a→b→c` dependency chain with `MaxConcurrency=1`, 5s timeout detects deadlock
- [x] `TestMaxConcurrencyDeadlockStress` — 100 rounds of concurrent stress
- [x] Full `go test ./... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)